### PR TITLE
feat: add `resizeMode` prop for video resizing

### DIFF
--- a/android/src/main/java/com/reactnativeamazonivs/AmazonIvsView.kt
+++ b/android/src/main/java/com/reactnativeamazonivs/AmazonIvsView.kt
@@ -100,13 +100,6 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
     }, 0, 1000)
   }
 
-  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
-    super.onLayout(changed, left, top, right, bottom)
-    if (changed) {
-      post(mLayoutRunnable)
-    }
-  }
-
   fun setStreamUrl(streamUrl: String) {
     player?.let { player ->
       val reactContext = context as ReactContext

--- a/android/src/main/java/com/reactnativeamazonivs/AmazonIvsView.kt
+++ b/android/src/main/java/com/reactnativeamazonivs/AmazonIvsView.kt
@@ -100,6 +100,13 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
     }, 0, 1000)
   }
 
+  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    super.onLayout(changed, left, top, right, bottom)
+    if (changed) {
+      post(mLayoutRunnable)
+    }
+  }
+
   fun setStreamUrl(streamUrl: String) {
     player?.let { player ->
       val reactContext = context as ReactContext

--- a/android/src/main/java/com/reactnativeamazonivs/AmazonIvsView.kt
+++ b/android/src/main/java/com/reactnativeamazonivs/AmazonIvsView.kt
@@ -100,6 +100,13 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
     }, 0, 1000)
   }
 
+  override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+    super.onLayout(changed, left, top, right, bottom)
+    if (changed) {
+      post(mLayoutRunnable)
+    }
+  }
+
   fun setStreamUrl(streamUrl: String) {
     player?.let { player ->
       val reactContext = context as ReactContext
@@ -136,6 +143,18 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
       2 -> player?.setLogLevel(Player.LogLevel.WARNING)
       3 -> player?.setLogLevel(Player.LogLevel.ERROR)
     }
+  }
+
+
+  fun setResizeMode(resizeMode: String?) {
+    playerView?.resizeMode = findResizeMode(resizeMode)
+  }
+
+  private fun findResizeMode(mode: String?): ResizeMode = when (mode) {
+      "aspectFill" -> ResizeMode.FILL
+      "aspectFit" -> ResizeMode.FIT
+      "aspectZoom" -> ResizeMode.ZOOM
+      else -> ResizeMode.FIT
   }
 
   private fun findQuality(quality: ReadableMap?): Quality? {
@@ -192,6 +211,7 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
     val valueInMilliseconds = duration * 1000
     player?.setInitialBufferDuration(valueInMilliseconds.toLong())
   }
+
 
   fun onTextMetadataCue(cue: TextMetadataCue) {
     val reactContext = context as ReactContext

--- a/android/src/main/java/com/reactnativeamazonivs/AmazonIvsViewManager.kt
+++ b/android/src/main/java/com/reactnativeamazonivs/AmazonIvsViewManager.kt
@@ -54,6 +54,11 @@ class AmazonIvsViewManager : SimpleViewManager<AmazonIvsView>() {
     view.setStreamUrl(streamUrl);
   }
 
+  @ReactProp(name = "resizeMode")
+  fun setResizeMode(view: AmazonIvsView, mode: String) {
+    view.setResizeMode(mode);
+  }
+
   @ReactProp(name = "muted")
   fun setMuted(view: AmazonIvsView, muted: Boolean) {
     view.setMuted(muted)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -485,7 +485,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: 224c36dc66fdc08af35c14afba83eb237235dba7
+  FBReactNativeSpec: d83fd664a8f4e8f899ca1b2637d0f54e0e1fd7bd
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 6d3e854f0e7260a648badd0d44fc364bc9da9728

--- a/ios/AmazonIvsManager.m
+++ b/ios/AmazonIvsManager.m
@@ -2,6 +2,7 @@
 #import "RCTViewManager.h"
 
 @interface RCT_EXTERN_MODULE(AmazonIvsManager, RCTViewManager)
+RCT_EXPORT_VIEW_PROPERTY(resizeMode, NSString)
 RCT_EXPORT_VIEW_PROPERTY(muted, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(liveLowLatency, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(quality, NSDictionary)

--- a/ios/AmazonIvsView.swift
+++ b/ios/AmazonIvsView.swift
@@ -50,6 +50,8 @@ class AmazonIvsView: UIView, IVSPlayer.Delegate {
 
         self.addSubview(self.playerView)
         self.playerView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+        self.playerView.videoGravity = findResizeMode(mode: resizeMode)
+
         self.addProgressObserver()
         self.addPlayerObserver()
         self.addTimePointObserver()
@@ -178,6 +180,25 @@ class AmazonIvsView: UIView, IVSPlayer.Delegate {
             default:
                 break
             }
+        }
+    }
+
+    @objc var resizeMode: String? {
+        didSet{
+            playerView.videoGravity = findResizeMode(mode: resizeMode)
+        }
+    }
+    
+    private func findResizeMode(mode: String?) -> AVLayerVideoGravity {
+        switch mode {
+        case "aspectFill":
+            return  AVLayerVideoGravity.resizeAspectFill
+        case "aspectFit":
+            return AVLayerVideoGravity.resizeAspect
+        case "aspectZoom":
+            return AVLayerVideoGravity.resize
+        default:
+            return AVLayerVideoGravity.resizeAspect
         }
     }
     

--- a/src/IVSPlayer.js.flow
+++ b/src/IVSPlayer.js.flow
@@ -23,6 +23,7 @@ declare type Props = {|
   muted?: boolean,
   autoplay?: boolean,
   streamUrl?: string,
+  resizeMode?: 'aspectFill' | 'aspectFit' | 'aspectZoom',
   liveLowLatency?: boolean,
   playbackRate?: number,
   logLevel?: LogLevel,

--- a/src/IVSPlayer.tsx
+++ b/src/IVSPlayer.tsx
@@ -31,6 +31,7 @@ type IVSPlayerProps = {
   liveLowLatency?: boolean;
   playbackRate?: number;
   streamUrl?: string;
+  resizeMode?: 'aspectFill' | 'aspectFit' | 'aspectZoom';
   logLevel?: LogLevel;
   progressInterval?: number;
   volume?: number;
@@ -81,6 +82,7 @@ type Props = {
   liveLowLatency?: boolean;
   playbackRate?: number;
   logLevel?: LogLevel;
+  resizeMode?: 'aspectFill' | 'aspectFit' | 'aspectZoom';
   progressInterval?: number;
   volume?: number;
   quality?: Quality | null;
@@ -121,6 +123,7 @@ const IVSPlayerContainer = React.forwardRef<IVSPlayerRef, Props>(
       streamUrl,
       paused,
       muted,
+      resizeMode,
       autoplay = true,
       liveLowLatency,
       playbackRate,
@@ -315,6 +318,7 @@ const IVSPlayerContainer = React.forwardRef<IVSPlayerRef, Props>(
           playbackRate={playbackRate}
           streamUrl={streamUrl}
           logLevel={logLevel}
+          resizeMode={resizeMode}
           progressInterval={progressInterval}
           volume={volume}
           quality={quality}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/amazon-ivs-react-native/issues/12

Description of changes: 

1. prop resizeMode (aspectFill, aspectFit, aspectZoom) added
resizeMode default: resize aspectFit

2. (android) redraw playerView when layout change occurs (ex. keyboard input active etc.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.