### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/example/src/helpers.ts
+++ b/example/src/helpers.ts
@@ -5,5 +5,5 @@ export const parseSecondsToString = (seconds: number) => {
 
   const date = new Date(0);
   date.setSeconds(seconds);
-  return date.toISOString().substr(11, 8);
+  return date.toISOString().slice(11, 19);
 };


### PR DESCRIPTION
Description of changes:

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
