### PR TITLE
upgrade native SDK's

### DIFF
--- a/amazon-ivs-react-native-player.podspec
+++ b/amazon-ivs-react-native-player.podspec
@@ -27,5 +27,5 @@ Pod::Spec.new do |s|
 
 
   s.dependency "React-Core"
-  s.dependency "AmazonIVSPlayer", "~> 1.8.0"
+  s.dependency "AmazonIVSPlayer", "~> 1.8.2"
 end

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ AmazonIvs_kotlinVersion=1.3.50
 AmazonIvs_compileSdkVersion=30
 AmazonIvs_buildToolsVersion=30.0.2
 AmazonIvs_targetSdkVersion=30
-AmazonIvs_ivsVersion=1.8.0
+AmazonIvs_ivsVersion=1.10.0

--- a/e2e/playgroundPlayerEvents.e2e.js
+++ b/e2e/playgroundPlayerEvents.e2e.js
@@ -268,7 +268,7 @@ describe('Playground player events', () => {
     await waitFor(element(by.id('logLevelPicker')))
       .toBeVisible()
       .whileElement(by.id('modalScrollView'))
-      .scroll(50, 'down');
+      .scroll(150, 'down');
     await element(by.text('DEBUG').withAncestor(by.id('logLevelPicker'))).tap();
     await element(by.id('closeIcon')).tap();
 
@@ -286,7 +286,7 @@ describe('Playground player events', () => {
     await waitFor(element(by.id('autoMaxQualityPicker')))
       .toBeVisible()
       .whileElement(by.id('modalScrollView'))
-      .scroll(50, 'down');
+      .scroll(150, 'down');
     await element(
       by.text('720P').withAncestor(by.id('autoMaxQualityPicker'))
     ).tap();

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - amazon-ivs-react-native-player (1.1.0):
-    - AmazonIVSPlayer (~> 1.8.0)
+    - AmazonIVSPlayer (~> 1.8.2)
     - React-Core
-  - AmazonIVSPlayer (1.8.0)
+  - AmazonIVSPlayer (1.8.2)
   - appcenter-analytics (4.4.3):
     - AppCenter/Analytics (~> 4.0)
     - AppCenterReactNativeShared (~> 4.0)
@@ -462,19 +462,19 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  amazon-ivs-react-native-player: a32475954e14afe48dfb290a6534a54cfa6a998e
-  AmazonIVSPlayer: e4f8df3ece5ff03eb8d557242711476730af294d
+  amazon-ivs-react-native-player: 4f33d017b2e72d27584493dbbdd77643b60566f3
+  AmazonIVSPlayer: 5fa9ee5782d3f8e85ddcebf189fa9d9de6ae27e2
   AppCenter: b0b6f1190215b5f983c42934db718f3b46fff3c0
   appcenter-analytics: 1b32062da2e250c5e1396c678df8c6011ccbcf5a
   appcenter-core: 6ea4754df4a3d8917a5803e2681a58179d7f7a21
   appcenter-crashes: b079913ac0f0059e6cf39b7a805135223e508666
   AppCenterReactNativeShared: ac6961204492735ce2507df0a14ce59b13e9c1c5
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e5569e42a1c79ca00521846c223173a57aca1fe1
   FBReactNativeSpec: fe08c1cd7e2e205718d77ad14b34957cce949b58
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 4bf86c70714490bca4bf2696148638284622644b
   RCTTypeSafety: c475a7059eb77935fa53d2c17db299893f057d5d
@@ -512,4 +512,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 9fb0f5c63db9eaf6c76003bfbbca2c1ba785fdfa
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3


### PR DESCRIPTION
Upgrade native SDK's
```
iOS: 1.8.0 -> 1.8.2
Android: 1.8.0 -> 1.10.0
```

additionally there has been fixed the e2e test issue that occurred on iOS.