### PR TITLE
fix: autoplay on both android & iOS

### DIFF
--- a/src/IVSPlayer.tsx
+++ b/src/IVSPlayer.tsx
@@ -157,7 +157,6 @@ const IVSPlayerContainer = React.forwardRef<IVSPlayerRef, Props>(
     ref
   ) => {
     const mediaPlayerRef = useRef(null);
-    const initialized = useRef(false);
 
     const play = useCallback(() => {
       UIManager.dispatchViewManagerCommand(
@@ -185,15 +184,8 @@ const IVSPlayerContainer = React.forwardRef<IVSPlayerRef, Props>(
     }, []);
 
     useEffect(() => {
-      if (initialized.current || autoplay) {
-        if (paused) {
-          pause();
-        } else {
-          play();
-        }
-      }
-      initialized.current = true;
-    }, [pause, paused, play, autoplay]);
+      paused ? pause() : play();
+    }, [pause, paused, play]);
 
     useImperativeHandle(
       ref,
@@ -239,7 +231,7 @@ const IVSPlayerContainer = React.forwardRef<IVSPlayerRef, Props>(
         duration: number | null;
       }>
     ) => {
-      if (!paused) {
+      if (autoplay) {
         play();
       } else {
         pause();

--- a/src/IVSPlayer.tsx
+++ b/src/IVSPlayer.tsx
@@ -12,6 +12,7 @@ import {
   findNodeHandle,
   View,
   NativeSyntheticEvent,
+  Platform,
 } from 'react-native';
 import type { LogLevel, PlayerState } from './enums';
 import type {
@@ -157,6 +158,7 @@ const IVSPlayerContainer = React.forwardRef<IVSPlayerRef, Props>(
     ref
   ) => {
     const mediaPlayerRef = useRef(null);
+    const initialized = useRef(false);
 
     const play = useCallback(() => {
       UIManager.dispatchViewManagerCommand(
@@ -184,8 +186,15 @@ const IVSPlayerContainer = React.forwardRef<IVSPlayerRef, Props>(
     }, []);
 
     useEffect(() => {
-      paused ? pause() : play();
-    }, [pause, paused, play]);
+      if (initialized.current || autoplay) {
+        if (paused) {
+          pause();
+        } else {
+          play();
+        }
+      }
+      initialized.current = true;
+    }, [pause, paused, play, autoplay]);
 
     useImperativeHandle(
       ref,
@@ -231,10 +240,9 @@ const IVSPlayerContainer = React.forwardRef<IVSPlayerRef, Props>(
         duration: number | null;
       }>
     ) => {
-      if (autoplay) {
-        play();
-      } else {
-        pause();
+      if (Platform.OS === 'android') {
+        const shouldAutoPlay = autoplay && !paused;
+        shouldAutoPlay ? play() : pause();
       }
 
       const { duration } = event.nativeEvent;


### PR DESCRIPTION
Fixes issue #97

Description of changes:

The implementation of `autoplay` was broken, even if it was passed as `false` stream would still play. So the `onLoad` callback seemed ideal place to check if `autoplay` prop has been passed from the user. If it's `true` we call `pause` method and stop the stream. We had to provide custom implementation for `autoplay` because the underlying SDK itself doesn't yield this prop.

Usage:

```
  return <IVSPlayer
          autoplay={false}
          streamUrl={URL} />
```

Testing:

<details>
<Summary>Before autoplay on android</Summary>

https://user-images.githubusercontent.com/47336142/205951043-c86258ee-c525-4743-94d9-bbe96726d125.mp4

</details>

<details>
<Summary>After autoplay on android</Summary>

https://user-images.githubusercontent.com/47336142/205950978-4c7962c4-add4-46b8-ab35-632d52c71d5c.mp4

</details>

<details>
<Summary>Before autoplay on iOS</Summary>

https://user-images.githubusercontent.com/47336142/205950737-925bf521-229a-4a63-a300-a6f5d80d21fc.mp4

</details>

<details>
<Summary>After autoplay on iOS </Summary>

https://user-images.githubusercontent.com/47336142/205950852-0a3bfa47-3c64-4e63-b98c-5ec2dc345d56.mp4

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
