### PR TITLE
fix: crash when backgrounding on low-end android device

### DIFF
--- a/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsView.kt
+++ b/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsView.kt
@@ -440,15 +440,7 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
   override fun onHostResume() {
   }
 
-  @RequiresApi(Build.VERSION_CODES.N)
-  override fun onHostPause() {
-    val activity: Activity? = context.currentActivity
-    if (activity?.isInPictureInPictureMode == true) {
-      // Continue playback
-    } else {
-      pause()
-    }
-  }
+  override fun onHostPause() {}
 
   override fun onHostDestroy() {
     cleanup()


### PR DESCRIPTION
Fixes crash when app is backgrounded on low-end android devices.

Description of changes:

The `requiresApi` annotation on `onHostPause` makes the app crash on lower versions than Nougat. The safest way probably, is to use something like this inside `onHostPause`:

   ```
 override fun onHostPause() {
    val activity: Activity? = context.currentActivity
    var isPipMode = false
    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
        isPipMode = activity?.isInPictureInPictureMode == true
    }

    if (!isPipMode) {
      pause()
    }
  }

```

But since, we don't need to pause the video if app is in background, we can safely remove the implementations in `onHostPause`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
