### PR TITLE
fix: precise player position on android

### DIFF
--- a/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsView.kt
+++ b/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsView.kt
@@ -251,17 +251,19 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
   fun onSeek(position: Long) {
     val reactContext = context as ReactContext
     val data = Arguments.createMap()
-    data.putInt("position", TimeUnit.MILLISECONDS.toSeconds(position).toInt())
-
+    data.putDouble("position", convertMilliSecondsToSeconds(position))
     reactContext.getJSModule(RCTEventEmitter::class.java).receiveEvent(id, Events.SEEK.toString(), data)
   }
 
   fun onProgress(position: Long) {
     val reactContext = context as ReactContext
     val data = Arguments.createMap()
-    data.putInt("position", TimeUnit.MILLISECONDS.toSeconds(position).toInt())
-
+    data.putDouble("position", convertMilliSecondsToSeconds(position))
     reactContext.getJSModule(RCTEventEmitter::class.java).receiveEvent(id, Events.PROGRESS.toString(), data)
+  }
+
+  private fun convertMilliSecondsToSeconds (milliSeconds: Long): Double {
+    return milliSeconds / 1000.0;
   }
 
   private val mLayoutRunnable = Runnable {
@@ -397,8 +399,7 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
   }
 
   private fun getDuration(duration: Long): Double {
-    val durationInSeconds = TimeUnit.MILLISECONDS.toSeconds(duration).toInt()
-    return durationInSeconds.toDouble()
+    return convertMilliSecondsToSeconds(duration)
   }
 
   private fun mapPlayerState(state: Player.State): String {


### PR DESCRIPTION
Fixes Issue #91

Description of changes:

Due to `TimeUnit.MILLISECONDS.toSeconds()` wasn't correctly converting milliseconds to seconds, we had to provide a custom implementation to convert the milliseconds to seconds. Together with @david-pw, we decided to pursue this path.

After taking a deeper look at the places this `TimeUnit` utility was used in the code to help in conversion, it seemed fair to refactor those places to now use `convertMilliSecondsToSeconds` private function. Following are the areas that will now return the precise seconds:

- onDurationChange (dependent on getDuration)
- onLoad (dependent on getDuration)
- onVideoStatistics (dependent on getDuration)
- onSeek
- onProgress


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
