### PR TITLE
fix: when expression must be exhaustive by adding else branch

### DIFF
--- a/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsView.kt
+++ b/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsView.kt
@@ -319,7 +319,8 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
         data.putMap("playerData", playerData)
 
         reactContext.getJSModule(RCTEventEmitter::class.java).receiveEvent(id, Events.DATA.toString(), data)
-      };
+      }
+      else -> {}
     }
 
     val onStateChangeData = Arguments.createMap()


### PR DESCRIPTION
Fixes issue #106 

Description of changes:

In Kotlin 1.6.0, non-exhaustive `when` was marked as a compile-time warning, if used as a statement. In 1.7.0, a compile-time error is thrown to make this behaviour consistent with `when` expressions. More info [here](https://kotlinlang.org/docs/whatsnew16.html#stable-exhaustive-when-statements-for-enum-sealed-and-boolean-subjects)

For our use case, we added an empty else branch to the `when` statement on `Player.State`.

To test this, add `kotlinVersion= "1.7.0"` to `android/build.gradle` to the example project, like so:

```.gradle
buildscript {
    ext {
        buildToolsVersion = "30.0.2"
        minSdkVersion = 21
        compileSdkVersion = 30
        targetSdkVersion = 30
        ndkVersion = "21.4.7075529"
        kotlinVersion= "1.7.0"
    }
 // ...other stuff
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
