### PR TITLE
Android: Get double precision value from args of seekTo command

### DIFF
--- a/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsViewManager.kt
+++ b/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsViewManager.kt
@@ -44,7 +44,7 @@ class AmazonIvsViewManager : SimpleViewManager<AmazonIvsView>() {
       Commands.PAUSE.ordinal -> view.pause()
       Commands.TOGGLE_PIP.ordinal -> view.togglePip()
       Commands.SEEK_TO.ordinal -> {
-        args?.getInt(0)?.let { position ->
+        args?.getDouble(0)?.let { position ->
           view.seekTo(position.toLong())
         }
       }


### PR DESCRIPTION
Issue #, if available: #124

Description of changes: 

As-is: `seekTo()` on player of android with floating value argument occurs player seeking with integer position.
To be: getting double precision value of seekTo on `receiveCommand` and convert to Long value. solves #124 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
