### PR TITLE
fix: 99 - issue 99 - bubbling onError up

### DIFF
--- a/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsView.kt
+++ b/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsView.kt
@@ -93,7 +93,7 @@ class AmazonIvsView(private val context: ThemedReactContext) : FrameLayout(conte
       }
 
       override fun onError(e: PlayerException) {
-        onError(e.errorMessage)
+        onError(e.getErrorMessage())
       }
     }
 


### PR DESCRIPTION
Issue #99 

Description of changes:
onError was not getting to JS since it was using `e.message` instead of `PlayerException` `getErrorMessage` method as it suppose to be according to API

https://aws.github.io/amazon-ivs-player-docs/1.19.0/android/reference/com/amazonaws/ivs/player/PlayerException.html
