### PR TITLE
chore: bump IVS SDKs to 1.23.0

### DIFF
--- a/amazon-ivs-react-native-player.podspec
+++ b/amazon-ivs-react-native-player.podspec
@@ -27,5 +27,5 @@ Pod::Spec.new do |s|
 
 
   s.dependency "React-Core"
-  s.dependency "AmazonIVSPlayer", "~> 1.18.0"
+  s.dependency "AmazonIVSPlayer", "~> 1.23.0"
 end

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ AmazonIvs_kotlinVersion=1.6.10
 AmazonIvs_compileSdkVersion=31
 AmazonIvs_buildToolsVersion=31.0.0
 AmazonIvs_targetSdkVersion=31
-AmazonIvs_ivsVersion=1.18.0
+AmazonIvs_ivsVersion=1.23.0


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Bumping the iOS and Android IVS SDKs to the latest, `1.23.0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
