### PR TITLE
feat: enabling rc prerelease versions

### DIFF
--- a/scripts/release-create.ts
+++ b/scripts/release-create.ts
@@ -52,8 +52,7 @@ async function run() {
               // strips the patch, so prerelease will inc to rc.2
               version = version.replace(/\.[^.]*$/gm, '');
             }
-            // 1.2.3-rc.1 -> 1.2.3-rc.2 or
-            // 1.2.3-rc.1.2 -> 1.2.3-rc.1.3
+            // 1.2.3-rc.1 -> 1.2.3-rc.2
             // increments the last digit
             version = semver.inc(version, 'prerelease', 'rc', '1');
             break;
@@ -69,8 +68,8 @@ async function run() {
             }
             break;
           case 'prereleasedone':
-            // 1.2.3-rc.1.2 -> 1.2.3 or
-            // 1.2.3-rc.1 -> 1.2.3
+            // 1.2.3-rc.1 -> 1.2.3 or
+            // 1.2.3-rc.1.2 -> 1.2.3
             // removes -rc from version
             version = version.replace(/-rc.*/gm, '');
             break;

--- a/scripts/release-create.ts
+++ b/scripts/release-create.ts
@@ -7,42 +7,88 @@ import pkg from '../package.json';
 import { logError, logInfo } from './utils';
 
 async function run() {
+  const skipChecks = !!process.env.SKIP_CHECKS;
   const git = simpleGit();
   const status = await git.status();
 
-  if (status.current !== 'main') {
-    return logError('Must be on main branch to create a release branch');
-  }
+  if (!skipChecks) {
+    if (status.current !== 'main') {
+      return logError('Must be on main branch to create a release branch');
+    }
 
-  if (!status.isClean()) {
-    return logError('Cannot create release with dirty working tree');
-  }
+    if (!status.isClean()) {
+      return logError('Cannot create release with dirty working tree');
+    }
 
-  if (status.ahead > 0) {
-    return logError(
-      `Local commits on main must match with origin/main. You are ${status.ahead} commit(s) ahead`
-    );
-  }
+    if (status.ahead > 0) {
+      return logError(
+        `Local commits on main must match with origin/main. You are ${status.ahead} commit(s) ahead`
+      );
+    }
 
-  if (status.behind > 0) {
-    return logError(
-      `Local commits on main must match with origin/main. You are ${status.behind} commit(s) behind`
-    );
+    if (status.behind > 0) {
+      return logError(
+        `Local commits on main must match with origin/main. You are ${status.behind} commit(s) behind`
+      );
+    }
   }
 
   try {
-    const versions = (['major', 'minor', 'patch'] as semver.ReleaseType[]).map(
-      (type) => {
-        const version = semver.inc(pkg.version, type);
-        return { name: `${type} ${version}`, value: version };
+    // different behavior based on rc version or not
+    const prerelease = (semver.prerelease(pkg.version) ?? []).length;
+
+    let bumps = prerelease
+      ? ['prereleasenext', 'prereleasepatch', 'prereleasedone']
+      : ['premajor', 'preminor', 'prepatch', 'major', 'minor', 'patch'];
+
+    const versions = bumps.map((type) => {
+      let version: string | null = pkg.version;
+      if (version) {
+        const prereleasepatch = prerelease > 2;
+        switch (type) {
+          case 'prereleasenext':
+            version = semver.inc(
+              prereleasepatch ? version.replace(/\.[^.]*$/gm, '') : version,
+              'prerelease',
+              'rc',
+              '1'
+            );
+            break;
+          case 'prereleasepatch':
+            version = prereleasepatch
+              ? semver.inc(version, 'prerelease', 'rc', '1')
+              : `${version}.2`;
+            break;
+          case 'prereleasedone':
+            version = version.replace(/-rc.*/gm, '');
+            break;
+          case 'premajor':
+          case 'preminor':
+          case 'prepatch':
+          case 'prerelease':
+            version = semver.inc(
+              version,
+              type as semver.ReleaseType,
+              'rc',
+              '1'
+            );
+            break;
+          default:
+            version = semver.inc(version, type as semver.ReleaseType);
+            break;
+        }
+        if (!version) {
+          throw new Error(`Invalid version: ${version}`);
+        }
       }
-    );
+      return { name: `${type} ${version}`, value: version };
+    });
 
     const answers = await inquirer.prompt([
       {
         type: 'list',
         name: 'bump',
-        message: 'Select release type',
+        message: `${pkg.version}: select release type`,
         default: versions[1].value,
         choices: versions,
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3665,9 +3665,9 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001349, caniuse-lite@^1.0.30001400:
-  version "1.0.30001516"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz"
-  integrity sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==
+  version "1.0.30001581"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz"
+  integrity sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==
 
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
Description of changes:

This updates release branch creation to include rc releases.

Run with skip checks enabled to bypass the branch state checks
```bash
SKIP_CHECKS=1 yarn release:create
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
