### PR TITLE
fix: set pipController delegate to fix broken iOS PiP callback functions

### DIFF
--- a/ios/AmazonIvsView.swift
+++ b/ios/AmazonIvsView.swift
@@ -520,7 +520,7 @@ class AmazonIvsView: UIView, IVSPlayer.Delegate {
 
         self.pipController = pipController
         pipController.canStartPictureInPictureAutomaticallyFromInline = self.pipEnabled
-
+        pipController.delegate = self
     }
 }
 @available(iOS 15, *)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: While testing PiP functionality, I noticed that the `onPipChange` callback was not invoked while entering and exiting PiP on iOS testing with a real device. [According to the docs](https://developer.apple.com/documentation/avkit/adopting-picture-in-picture-in-a-custom-player), the class needs to be made the pipController delegate for these to work so this change adds that. I've verified that now the callback prop is invoked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
