### PR TITLE
ci(ios): fix dependency for e2e test run

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -86,6 +86,7 @@ jobs:
       - name: install detox deps
         run: |
           brew tap wix/brew
+          brew install applesimutils
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1


### PR DESCRIPTION
added missing applesimutils package required for e2e test run from brew