### PR TITLE
ci(android): migrate to Ubuntu runner for emulator tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -107,10 +107,18 @@ jobs:
         continue-on-error: true
 
   android:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Free Disk Space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
 
       - uses: actions/setup-java@v4
         with:
@@ -132,7 +140,13 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-31-arm64-macos
+          key: avd-31-ubuntu
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Install dependencies
         run: yarn bootstrap
@@ -140,11 +154,11 @@ jobs:
       - name: Build Android app
         run: yarn e2e:build:android:release
 
-      - name: Run tests on Android Emulator (ARM64)
+      - name: Run tests on Android Emulator (x86_64)
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 31
-          arch: arm64-v8a
+          arch: x86_64
           target: google_apis
           profile: pixel_6
           disable-animations: true


### PR DESCRIPTION
Switch from macOS to Ubuntu with x86_64 emulator to resolve HVF compatibility issues.

