### PR TITLE
fix(android): call cleanup on view drop to prevent resource leaks

### DIFF
--- a/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsViewManager.kt
+++ b/android/src/main/java/com/amazonaws/ivs/reactnative/player/AmazonIvsViewManager.kt
@@ -70,6 +70,10 @@ class AmazonIvsViewManager : SimpleViewManager<AmazonIvsView>(),
     return AmazonIvsView(context)
   }
 
+  override fun onDropViewInstance(view: AmazonIvsView) {
+    view.cleanup()
+    super.onDropViewInstance(view)
+  }
 
   override fun setMuted(
     view: AmazonIvsView?,


### PR DESCRIPTION
  Currently, `AmazonIvsView.cleanup()` is only called from `onHostDestroy`, which is tied to the Android Activity lifecycle. When a React component is unmounted (e.g. navigating away via React Navigation), the Activity remains alive — so `onHostDestroy` is never called, and player resources (IVS player instance, listeners,  background service, preloaded sources, timers, broadcast receivers) are never released.

In our production app, we observed that player resources were not being released when the component was unmounted, causing resource leaks.

  This adds an `onDropViewInstance` override in `AmazonIvsViewManager` to call `cleanup()` when React drops the native view.